### PR TITLE
avformat/mov : (fix) dv audio is be pcm

### DIFF
--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1444,7 +1444,7 @@ int ff_mov_read_stsd_entries(MOVContext *c, AVIOContext *pb, int entries)
             return -1;
         }
         sc->dv_audio_container = 1;
-        st->codec->codec_id = CODEC_ID_PCM_S16LE;
+        st->codec->codec_id = CODEC_ID_PCM_S16BE;
         break;
 #endif
     /* no ifdef since parameters are always those */


### PR DESCRIPTION
fixes playback of 
http://samples.ffmpeg.org/ffmpeg-bugs/trac/ticket4671/dir1.tar.bz2

./ffplay -enable_drefs 1 -i dir1/movie2.mov