### PR TITLE
libavformat/os_support.h: Fix POLLFD for mingw-w64

### DIFF
--- a/libavformat/os_support.h
+++ b/libavformat/os_support.h
@@ -63,6 +63,17 @@ typedef int socklen_t;
 #if !HAVE_POLL_H
 typedef unsigned long nfds_t;
 
+#if HAVE_WINSOCK2_H
+#include <winsock2.h>
+#define HAVE_STRUCT_POLLFD 1
+#else
+#include <poll.h>
+#define HAVE_STRUCT_POLLFD 0
+#endif
+
+
+#if !HAVE_STRUCT_POLLFD
+
 struct pollfd {
     int fd;
     short events;  /* events to look for */
@@ -84,7 +95,10 @@ struct pollfd {
 #define POLLNVAL   0x1000  /* invalid file descriptor */
 
 
-int poll(struct pollfd *fds, nfds_t numfds, int timeout);
+#endif
+
+int ff_poll(struct pollfd *fds, nfds_t numfds, int timeout);
+#define poll ff_poll
 #endif /* HAVE_POLL_H */
 #endif /* CONFIG_NETWORK */
 


### PR DESCRIPTION
fixes issues such as

```c
In file included from C:/media-autobuild_suite-master/build/FFmbc-git/libavformat/network.h:31,
                 from C:/media-autobuild_suite-master/build/FFmbc-git/libavformat/avio.c:29:
C:/media-autobuild_suite-master/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:1185:16: error: redefinition of 'struct pollfd'
 1185 | typedef struct pollfd {
      |                ^~~~~~
In file included from C:/media-autobuild_suite-master/build/FFmbc-git/libavformat/avio.c:26:
C:/media-autobuild_suite-master/build/FFmbc-git/libavformat/os_support.h:66:8: note: originally defined here
   66 | struct pollfd {
      |        ^~~~~~
```

Signed-off-by: Christopher Degawa <ccom@randomderp.com>